### PR TITLE
very specific bug patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Share (and sync) Objects Online with the power of websockets. Keys, Values AND R
 <br>
 **Please note**:
 - To view example usage of the modules this library provides, please refer to the _[tests](https://github.com/Y0ursTruly/webject/blob/main/tests.js)_
-- Version 1.4 includes breaking changes relative to every version below in terms of the arguments order and slightly the logic in the `connect` module and the change from serve(...).authTokens from an Object to a Map
+- Version 1.4.x includes breaking changes relative to every version below in terms of the arguments order and slightly the logic in the `connect` module and the change from serve(...).authTokens from an Object to a Map
+- Previous Version 1.4.1 had a blunder with handling what it received from the websocket in EXACTLY ONE case (the updated ws had a datatype change for it in 2 places and I only managed to change for 1) which would make a valid client end up doing pointless reconnections.. needless to say the ONE test I commented would have saved this, so it is uncommented, lesson learned ;-;
 
 # Installation
 Multiple ways

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webject",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webject",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webject",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Share Objects Online with the power of websockets. Keys, Values AND references. Webject is short for Web Object and it really is a system for sharing objects on the web. Someone can host an object, and make authTokens for others online to share this object",
   "main": "webject.js",
   "scripts": {

--- a/tests.js
+++ b/tests.js
@@ -127,12 +127,12 @@ const {serve, connect, sync, desync, objToString, stringToObj, partFilter, objVa
         //"magic string" source: webject.js line 318
       }
     })
-    /*await t.test("Ensuring ping logic doesn't disconnect you",async function(){
+    await t.test("Ensuring ping logic doesn't disconnect you",async function(){
       await new Promise(r=>setTimeout(r,5001))
       mainObj.newkeyy=3;
       await sharedObjectsEqual(sharedObj,sharedObj1)
       //this test is long and arduous and the automated check stops on it even though it will pass
-    })*/
+    })
     await t.test("authLevel 2 and 3 tokens",async function(){
       let temp2=await connect(serverLocation,lvl2Key,null,null,false) //can only insert new items
       let temp3=await connect(serverLocation,lvl3Key,null,null,false) //can delete, modify, insert new items

--- a/tests.js
+++ b/tests.js
@@ -131,7 +131,6 @@ const {serve, connect, sync, desync, objToString, stringToObj, partFilter, objVa
       await new Promise(r=>setTimeout(r,5001))
       mainObj.newkeyy=3;
       await sharedObjectsEqual(sharedObj,sharedObj1)
-      //this test is long and arduous and the automated check stops on it even though it will pass
     })
     await t.test("authLevel 2 and 3 tokens",async function(){
       let temp2=await connect(serverLocation,lvl2Key,null,null,false) //can only insert new items

--- a/webject.js
+++ b/webject.js
@@ -211,7 +211,7 @@
       
       client.on('message',async(msg)=>{
         //heartbeat handling start
-        if(msg==="PING"&&clientMsgCount===1){
+        if(msg=="PING"&&clientMsgCount===1){
           //ping received with a socket that has SUCCESSFULLY CONNECTED
           //now I am sending own ping
           if(new Date()-lastPing<2500) return client.close(1000); //why are you pinging early? spammer?


### PR DESCRIPTION
Previous Version 1.4.1 had a blunder with handling what it received from the websocket in EXACTLY ONE case (the updated ws had a datatype change for it in 2 places and I only managed to change for 1) which would make a valid client end up doing pointless reconnections.. needless to say the ONE test I commented would have saved this, so it is uncommented, lesson learned ;-;